### PR TITLE
Adding some rules regarding spacing

### DIFF
--- a/index.json
+++ b/index.json
@@ -8,6 +8,7 @@
   "rules": {
     "consistent-return": 0,
     "curly": [ 2, "multi-line" ],
+    "generator-star-spacing": [ 2, "after" ],
     "no-octal-escape": 0,
     "no-process-exit": 0,
     "no-shadow": 0,
@@ -15,6 +16,13 @@
     "no-underscore-dangle": 0,
     "no-unused-expressions": 0,
     "no-use-before-define": [ 2, "nofunc" ],
+    "space-after-keywords": [ 2, "always" ],
+    "space-before-blocks": [ 2, "always" ],
+    "space-before-function-paren": [ 2, { "anonymous": "always", "named": "never" } ],
+    "space-in-parens": [ 2, "never" ],
+    "space-infix-ops": 2,
+    "space-return-throw-case": 2,
+    "space-unary-ops": 2,
     "strict": 0,
     "quotes": [ 2, "single" ]
   }


### PR DESCRIPTION
I've added the following rules to specifically address the spacing for `duojs` code. I'm open to changes here, but here are links to all the relevant rules:
- [generator-star-spacing](http://eslint.org/docs/rules/generator-star-spacing)
- [space-after-keywords](http://eslint.org/docs/rules/space-after-keywords)
- [space-before-blocks](http://eslint.org/docs/rules/space-before-blocks)
- [space-before-function-paren](http://eslint.org/docs/rules/space-before-function-paren)
- [space-in-parens](http://eslint.org/docs/rules/space-in-parens)
- [space-infix-ops](http://eslint.org/docs/rules/space-infix-ops)
- [space-return-throw-case](http://eslint.org/docs/rules/space-return-throw-case)
- [space-unary-ops](http://eslint.org/docs/rules/space-unary-ops)

I've made them errors (which will cause CI to fail) since changing them will not affect how the code itself runs. (so we aren't forced to make logical changes in order to pass)
